### PR TITLE
Fixed A Bug With Daylight Savings Resulting In Some Weeks Having 6 Days

### DIFF
--- a/lib/src/widget/heatmap_column.dart
+++ b/lib/src/widget/heatmap_column.dart
@@ -69,11 +69,16 @@ class HeatMapColumn extends StatelessWidget {
   /// Show day text in every blocks if the value is true.
   final bool? showText;
 
+  // The number of day blocks to draw. This should be seven for all but the
+  // current week.
+  final int numDays;
+
   HeatMapColumn({
     Key? key,
     required this.startDate,
     required this.endDate,
     required this.colorMode,
+    required this.numDays,
     this.size,
     this.fontSize,
     this.defaultColor,
@@ -88,7 +93,7 @@ class HeatMapColumn extends StatelessWidget {
   })  :
         // Init list.
         dayContainers = List.generate(
-          endDate.difference(startDate).inDays + 1,
+          numDays,
           (i) => HeatMapContainer(
             date: DateUtil.changeDay(startDate, i),
             backgroundColor: defaultColor,
@@ -131,9 +136,9 @@ class HeatMapColumn extends StatelessWidget {
           ),
         ),
         // Fill emptySpace list only if given wek doesn't have 7 days.
-        emptySpace = (endDate.difference(startDate).inDays != 6)
+        emptySpace = (numDays != 7)
             ? List.generate(
-                6 - endDate.difference(startDate).inDays,
+                7 - numDays,
                 (i) => Container(
                     margin: margin ?? const EdgeInsets.all(2),
                     width: size ?? 42,

--- a/lib/src/widget/heatmap_page.dart
+++ b/lib/src/widget/heatmap_page.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:flutter/material.dart';
 import './heatmap_month_text.dart';
 import './heatmap_column.dart';
@@ -116,6 +118,7 @@ class HeatMapPage extends StatelessWidget {
             ? DateUtil.changeDay(startDate, datePos + 6)
             : endDate,
         colorMode: colorMode,
+        numDays: min(endDate.difference(_firstDay).inDays + 1, 7),
         size: size,
         fontSize: fontSize,
         defaultColor: defaultColor,


### PR DESCRIPTION
The bug was due to the number of days being the end time minus the start time resulting in 7 days minus 1 hour which is interpreted as 6 days. This fix makes it so all weeks before the current week automatically have 7 days.