### PR TITLE
fixed bug where app would have overflow render crash if start date was today

### DIFF
--- a/lib/src/widget/heatmap_month_text.dart
+++ b/lib/src/widget/heatmap_month_text.dart
@@ -46,7 +46,7 @@ class HeatMapMonthText extends StatelessWidget {
         // Add Text without width margin if first week is end of the month.
         // Otherwise, add Text with width margin.
         items.add(
-          label == 0 && firstDayInfos![label] != firstDayInfos![label + 1]
+          firstDayInfos!.length == 1 || (label == 0 && firstDayInfos![label] != firstDayInfos![label + 1])
               ? _renderText(DateUtil.SHORT_MONTH_LABEL[firstDayInfos![label]])
               : Container(
                   width: (((size ?? 20) + (margin?.right ?? 2)) * 2),


### PR DESCRIPTION
Hi, thanks the for the awesome library, I ran into a bug when displaying the heatmap with one days info (todays) it would cause a render overflow and red screen in my flutter app. Heres a snippet of code that I tested this change with.

```
import 'package:flutter/material.dart';
import 'package:flutter_heatmap_calendar/flutter_heatmap_calendar.dart';

void main() {
  runApp(const MyApp());
}

class MyApp extends StatelessWidget {
  const MyApp({Key? key}) : super(key: key);

  @override
  Widget build(BuildContext context) {
    DateTime now = DateTime.now();
    DateTime today = DateTime(now.year, now.month, now.day);

    return MaterialApp(
      home: Scaffold(
          appBar: AppBar(),
          body: HeatMap(
            showColorTip: false,
            startDate: today,
            datasets: {today: 1},
            colorsets: const {1: Colors.green},
          )),
    );
  }
}

```