### PR TITLE
Expose `ScrollController` on `HeatMap`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.6
+
+- fix: Expose `ScrollController` on `HeatMap`.
+
 ## 1.0.5
 
 - feat: Created the `onMonthChange` callback on the `HeatMapCalendar`.

--- a/lib/src/heatmap.dart
+++ b/lib/src/heatmap.dart
@@ -74,6 +74,10 @@ class HeatMap extends StatefulWidget {
   /// default value is false.
   final bool scrollable;
 
+  /// An object that can be used to control the position to which this scroll
+  /// view is scrolled.
+  final ScrollController? scrollController;
+
   /// Widgets which shown at left and right side of colorTip.
   ///
   /// First value is the left side widget and second value is the right side widget.
@@ -104,6 +108,7 @@ class HeatMap extends StatefulWidget {
     this.showText = false,
     this.showColorTip = true,
     this.scrollable = false,
+    this.scrollController,
     this.colorTipHelper,
     this.colorTipCount,
     this.colorTipSize,
@@ -119,6 +124,7 @@ class _HeatMap extends State<HeatMap> {
     return widget.scrollable
         ? SingleChildScrollView(
             reverse: true,
+            controller: widget.scrollController,
             scrollDirection: Axis.horizontal,
             child: child,
           )


### PR DESCRIPTION
For cases when the `HeatMap` is `scrollable ` a  `ScrollController` is much needed as it is absent by default.

fixes #15

cc: @devappmin 